### PR TITLE
Update TYPO3 github repository url

### DIFF
--- a/data/table.yml
+++ b/data/table.yml
@@ -443,7 +443,7 @@
 -
     name: 'Typo 3'
     site: 'https://typo3.org'
-    repository: 'https://github.com/TYPO3/TYPO3.CMS'
+    repository: 'https://github.com/TYPO3/typo3'
     docs: 'https://typo3.org/help/documentation'
     open_issues: 5
     opened_recently: 0


### PR DESCRIPTION
Typo 3 is not longer updated, think its because of renaming there repository url.